### PR TITLE
fix: X-Cart ShipNotify tracking creation

### DIFF
--- a/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
+++ b/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
@@ -38,7 +38,10 @@ class Order extends \XLite\Model\Repo\ARepo implements \XLite\Base\IDecorator
      */
     public function addOrderTrackingNumber($intOrderNumber = 0, $intTrackingNumber = 0) 
     {
-        \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES ($intOrderNumber, '$intTrackingNumber', NOW())");
+        \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES (:order_id, :tracking_number, NOW())", array(
+            ':order_id' => $intOrderNumber,
+            ':tracking_number' => $intTrackingNumber
+        ));
     }
     /**
      * Set the Shipping Service Mappings

--- a/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
+++ b/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
@@ -38,7 +38,7 @@ class Order extends \XLite\Model\Repo\ARepo implements \XLite\Base\IDecorator
      */
     public function addOrderTrackingNumber($intOrderNumber = 0, $intTrackingNumber = 0) 
     {
-        \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creation_date) VALUES ($intOrderNumber, '$intTrackingNumber', NOW())");
+        \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES ($intOrderNumber, '$intTrackingNumber', NOW())");
     }
     /**
      * Set the Shipping Service Mappings

--- a/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
+++ b/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
@@ -38,7 +38,7 @@ class Order extends \XLite\Model\Repo\ARepo implements \XLite\Base\IDecorator
      */
     public function addOrderTrackingNumber($intOrderNumber = 0, $intTrackingNumber = 0) 
     {
-        \Includes\Utils\Database::execute("INSERT INTo " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number(order_id,value) VALUES($intOrderNumber,'$intTrackingNumber')");
+        \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creation_date) VALUES ($intOrderNumber, '$intTrackingNumber', NOW())");
     }
     /**
      * Set the Shipping Service Mappings


### PR DESCRIPTION
We need to default the creation_date field in order_tracking_number to
create the tracking record successfully.

https://shipstation.atlassian.net/browse/INT-385