### PR TITLE
Support 5.4 and older versions of the x-cart plugin

### DIFF
--- a/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
+++ b/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
@@ -38,10 +38,17 @@ class Order extends \XLite\Model\Repo\ARepo implements \XLite\Base\IDecorator
      */
     public function addOrderTrackingNumber($intOrderNumber = 0, $intTrackingNumber = 0) 
     {
-        \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES (:order_id, :tracking_number, NOW())", array(
-            ':order_id' => $intOrderNumber,
-            ':tracking_number' => $intTrackingNumber
-        ));
+        if (\XLite\Module\ShipStation\Api\Main::getMajorVersion() == '5.4') {
+            \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES (:order_id, :tracking_number, NOW())", array(
+                ':order_id' => $intOrderNumber,
+                ':tracking_number' => $intTrackingNumber
+            ));
+        } else {
+            \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value) VALUES (:order_id, :tracking_number)", array(
+                ':order_id' => $intOrderNumber,
+                ':tracking_number' => $intTrackingNumber
+            ));
+        }
     }
     /**
      * Set the Shipping Service Mappings

--- a/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
+++ b/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
@@ -38,7 +38,8 @@ class Order extends \XLite\Model\Repo\ARepo implements \XLite\Base\IDecorator
      */
     public function addOrderTrackingNumber($intOrderNumber = 0, $intTrackingNumber = 0) 
     {
-        if (\XLite\Module\ShipStation\Api\Main::getMajorVersion() == '5.4') {
+        $version = \XLite\Module\ShipStation\Api\Main::getMajorVersion();
+        if (floatval($version) >= 5.4) {
             \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES (:order_id, :tracking_number, NOW())", array(
                 ':order_id' => $intOrderNumber,
                 ':tracking_number' => $intTrackingNumber


### PR DESCRIPTION
- Insert `creationDate` into order_tracking_number only if the major version is 5.4. 
- All other versions fall back to the old logic which just inserts `order_id` and `value` as the `creation_date` column will not exist in those versions.