### PR TITLE
Update minor version to 5.4.1 and use unix_timestamp instead of now

### DIFF
--- a/classes/XLite/Module/ShipStation/Api/Main.php
+++ b/classes/XLite/Module/ShipStation/Api/Main.php
@@ -54,7 +54,7 @@ abstract class Main extends \XLite\Module\AModule
      */
     public static function getMinorVersion() 
     {
-        return '2';
+        return '1';
     }
 
     /**

--- a/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
+++ b/classes/XLite/Module/ShipStation/Api/Model/Repo/Order.php
@@ -40,7 +40,7 @@ class Order extends \XLite\Model\Repo\ARepo implements \XLite\Base\IDecorator
     {
         $version = \XLite\Module\ShipStation\Api\Main::getMajorVersion();
         if (floatval($version) >= 5.4) {
-            \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES (:order_id, :tracking_number, NOW())", array(
+            \Includes\Utils\Database::execute("INSERT INTO " . \Includes\Utils\Database::getTablesPrefix() . "order_tracking_number (order_id, value, creationDate) VALUES (:order_id, :tracking_number, UNIX_TIMESTAMP())", array(
                 ':order_id' => $intOrderNumber,
                 ':tracking_number' => $intTrackingNumber
             ));

--- a/classes/XLite/Module/ShipStation/Api/changelog/5.4/1/0.log
+++ b/classes/XLite/Module/ShipStation/Api/changelog/5.4/1/0.log
@@ -1,0 +1,2 @@
+Version 5.4.1
+01/05/2021 - [Bug] Small fixes for versions compatibility

--- a/classes/XLite/Module/ShipStation/Api/main.yaml
+++ b/classes/XLite/Module/ShipStation/Api/main.yaml
@@ -1,4 +1,4 @@
-version: 5.4.2
+version: 5.4.1
 type: common
 authorName: ShipStation
 moduleName: ShipStation


### PR DESCRIPTION
- Correctly report minor version as 1 so the full version is 5.4.1
- Added changelog for minor update
- Use UNIX_TIMESTAMP() instead of NOW() in order_tracking_number insert as the creationDate column is an integer