### PR TITLE
INT-3861 - X-cart SS plugin: pull company name field with the rest of the customer’s address

### DIFF
--- a/classes/XLite/Module/ShipStation/Api/Controller/Customer/Api.php
+++ b/classes/XLite/Module/ShipStation/Api/Controller/Customer/Api.php
@@ -250,6 +250,7 @@ class Api extends \XLite\Controller\Customer\ACustomer
                     $this->addFieldToXML("Country", $objBillingAddress->getCountry()->getCountry());
                     $this->addFieldToXML("CountryCode", $objBillingAddress->getCountry()->getCode());
                 }
+                $this->addFieldToXML("Company", $objBillingAddress->getCompanyName());
                 $this->addFieldToXML("Phone", $objBillingAddress->getPhone());
                 $this->addFieldToXML("Email", $objOrder->getProfile()->getLogin());
                 $this->xmlData .= "\t</BillTo>\n";

--- a/classes/XLite/Module/ShipStation/Api/Controller/Customer/Api.php
+++ b/classes/XLite/Module/ShipStation/Api/Controller/Customer/Api.php
@@ -285,6 +285,7 @@ class Api extends \XLite\Controller\Customer\ACustomer
                     $this->addFieldToXML("Country", $objShippingAddress->getCountry()->getCountry());
                     $this->addFieldToXML("CountryCode", $objShippingAddress->getCountry()->getCode());
                 }
+                $this->addFieldToXML("Company", $objShippingAddress->getCompanyName());
                 $this->addFieldToXML("Phone", $objShippingAddress->getPhone());
                 $this->addFieldToXML("Email", $objOrder->getProfile()->getLogin());
                 $this->xmlData .= "\t</ShipTo>\n";

--- a/classes/XLite/Module/ShipStation/Api/Main.php
+++ b/classes/XLite/Module/ShipStation/Api/Main.php
@@ -54,7 +54,7 @@ abstract class Main extends \XLite\Module\AModule
      */
     public static function getMinorVersion() 
     {
-        return '1';
+        return '1.2';
     }
 
     /**

--- a/classes/XLite/Module/ShipStation/Api/changelog/5.4/1/1.log
+++ b/classes/XLite/Module/ShipStation/Api/changelog/5.4/1/1.log
@@ -1,0 +1,2 @@
+Version 5.4.1.1
+01/08/2021 - [Bug] Small fixes for versions compatibility

--- a/classes/XLite/Module/ShipStation/Api/changelog/5.4/1/2.log
+++ b/classes/XLite/Module/ShipStation/Api/changelog/5.4/1/2.log
@@ -1,0 +1,2 @@
+Version 5.4.1.2
+02/10/2021 - [Changes] Import "company name" field with Orders

--- a/classes/XLite/Module/ShipStation/Api/main.yaml
+++ b/classes/XLite/Module/ShipStation/Api/main.yaml
@@ -1,4 +1,4 @@
-version: 5.4.1
+version: 5.4.1.2
 type: common
 authorName: ShipStation
 moduleName: ShipStation


### PR DESCRIPTION
### Ticket: 
https://auctane.atlassian.net/browse/INT-3861

### Changes:

Import customer billing and shipping address company field

### Tests performed:

Ran locally to confirm changes. Then tested in stage (Z):

- Installed updated module version 5.4.1.2 into Cloudways test store
- Updated test store's address form fields to contain company name
- Redeployed test store
- Tested in stage & verified that existing orders were imported (without company name field on address) & that new orders with company field were imported. Observed in ShipStation that company is present